### PR TITLE
content length計算修正

### DIFF
--- a/PFFIAPUploadAgent.cpp
+++ b/PFFIAPUploadAgent.cpp
@@ -93,7 +93,7 @@ int FIAPUploadAgent::post(struct fiap_element* v, byte esize){
     clen += strlen(fiap_id_prefix.c_str());
     clen += strlen(v0->cid);
     clen += strlen(v0->value);
-    clen += 44;
+    clen += 69;
     v0++;
   } // Serial.print("len="); Serial.println(clen);
 

--- a/PFFIAPUploadAgent.cpp
+++ b/PFFIAPUploadAgent.cpp
@@ -88,12 +88,12 @@ int FIAPUploadAgent::post(struct fiap_element* v, byte esize){
   // TCP接続成功
   // コンテンツサイズ計算
   v0 = v;
-  clen = 320; // sum of literal strings
+  clen = 294; // sum of literal strings
   for (count = 0; count < esize; count++) {
     clen += strlen(fiap_id_prefix.c_str());
     clen += strlen(v0->cid);
-    clen += strlen(v0->value); // + 3;
-    clen += 75;
+    clen += strlen(v0->value);
+    clen += 44;
     v0++;
   } // Serial.print("len="); Serial.println(clen);
 
@@ -122,19 +122,19 @@ int FIAPUploadAgent::post(struct fiap_element* v, byte esize){
 
   // send HTTP body
   strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY01);
-  client.println(sbuf); // "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+  client.print(sbuf); // "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
   strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY02);
   client.print(sbuf); // "<soapenv:Envelope xmlns:soapenv="
   strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY03);
-  client.println(sbuf); // "\"http://schemas.xmlsoap.org/soap/envelope/\">"
+  client.print(sbuf); // "\"http://schemas.xmlsoap.org/soap/envelope/\">"
   strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY04);
-  client.println(sbuf); // "<soapenv:Body>"
+  client.print(sbuf); // "<soapenv:Body>"
   strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY05);
-  client.println(sbuf); // "<ns2:dataRQ xmlns:ns2=\"http://soap.fiap.org/\">"
+  client.print(sbuf); // "<ns2:dataRQ xmlns:ns2=\"http://soap.fiap.org/\">"
   strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY06);
-  client.println(sbuf); // "<transport xmlns=\"http://gutp.jp/fiap/2009/11/\">"
+  client.print(sbuf); // "<transport xmlns=\"http://gutp.jp/fiap/2009/11/\">"
   strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY07);
-  client.println(sbuf); // "<body>"
+  client.print(sbuf); // "<body>"
 
 
   v0=v;
@@ -143,7 +143,7 @@ int FIAPUploadAgent::post(struct fiap_element* v, byte esize){
     client.print(sbuf); // "<point id=\""
     client.print(fiap_id_prefix.c_str()); client.print(v0->cid);
     strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY11);
-    client.println(sbuf); // "\">"
+    client.print(sbuf); // "\">"
 
     strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY12);
     client.print(sbuf); // "<value time=\""
@@ -153,23 +153,23 @@ int FIAPUploadAgent::post(struct fiap_element* v, byte esize){
     client.print(v0->value);
 
     strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY14);
-    client.println(sbuf); // "</value>"
+    client.print(sbuf); // "</value>"
 
     strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY15);
-    client.println(sbuf); // "</point>"
+    client.print(sbuf); // "</point>"
     v0++;
   }
   strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY17);
-  client.println(sbuf); // "</body>"
+  client.print(sbuf); // "</body>"
   strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY18);
-  client.println(sbuf); // "</transport>"
+  client.print(sbuf); // "</transport>"
   strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY19);
-  client.println(sbuf); // "</ns2:dataRQ>"
+  client.print(sbuf); // "</ns2:dataRQ>"
   strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY20);
-  client.println(sbuf); // "</soapenv:Body>"
+  client.print(sbuf); // "</soapenv:Body>"
   strcpy_P(sbuf,FIAPUploadAgent_Post_HTTPBODY21);
-  client.println(sbuf); // "</soapenv:Envelope>"
-  client.println();
+  client.print(sbuf); // "</soapenv:Envelope>"
+  // client.println();
 
   // parse HTTP response
   count = 0;

--- a/PFFIAPUploadAgent.cpp
+++ b/PFFIAPUploadAgent.cpp
@@ -177,7 +177,7 @@ int FIAPUploadAgent::post(struct fiap_element* v, byte esize){
     // Serial.print("C");
     if (client.available()) {
       c = client.read();  // Serial.print(c);
-      if (count == 1 && (c >= '0' && c <= '9')) {  // parse HTTP response code
+      if (count == 1 && isDigit(c)) {  // parse HTTP response code
         rescode = rescode * 10 + (c - '0');
         continue;
       }

--- a/PFFIAPUploadAgent.cpp
+++ b/PFFIAPUploadAgent.cpp
@@ -75,6 +75,7 @@ int FIAPUploadAgent::post(struct fiap_element* v, byte esize){
   int clen = 0;     // content length
   struct fiap_element *v0;
   char count;
+  unsigned int receive_loop_count;
   unsigned char c;
 
   EthernetClient client;
@@ -173,6 +174,7 @@ int FIAPUploadAgent::post(struct fiap_element* v, byte esize){
 
   // parse HTTP response
   count = 0;
+  receive_loop_count = 0;
   while (client.connected()) {
     // Serial.print("C");
     if (client.available()) {
@@ -188,6 +190,12 @@ int FIAPUploadAgent::post(struct fiap_element* v, byte esize){
         break;    // 応答ヘッダの2行目以降は見ない
       }
     }
+    receive_loop_count++;
+    if(receive_loop_count >= FIAP_RESPONSE_TIMEOUT) {
+      client.stop();
+      return(FIAP_UPLOAD_HTTPTOERR);
+    }
+    delayMicroseconds(1);
   }
   if (!client.connected()) {  // unexpected disconnect
     client.stop();

--- a/PFFIAPUploadAgent.h
+++ b/PFFIAPUploadAgent.h
@@ -6,12 +6,15 @@
 #ifndef __FIAPUploadAgent__
 #define __FIAPUploadAgent__
 
+#define FIAP_RESPONSE_TIMEOUT 500000 // 500ms
+
 // return code of post method
 #define FIAP_UPLOAD_OK       0  // Succeeded
 #define FIAP_UPLOAD_CONNFAIL 1  // Connection faild (Socket I/O error)
 #define FIAP_UPLOAD_DNSERR   2  // DNS error
 #define FIAP_UPLOAD_HTTPERR  3  // HTTP Server error (The response was not "200 OK")
 #define FIAP_UPLOAD_FIAPERR  4  // FIAP Server error
+#define FIAP_UPLOAD_HTTPTOERR 5  // HTTP Timeout error
 
 #include <Arduino.h>
 #include "TimeLib.h"


### PR DESCRIPTION
issue #6 

* content-length計算式修正
* HTTPペイロード内の改行を削除
* 数字判定をArduino関数に変更
* サーバーからのレスポンスタイムアウトを設定

content length適正設定により，サーバー側でのタイムアウトを待たなくなったので
アップロード処理が高速化しました．